### PR TITLE
Update vercel deployment to branch deployment

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -2,12 +2,13 @@ name: Deploy examples to Vercel
 env:
   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 on:
+  pull_request:
   push:
     branches:
       - main
-      #- 56-setup-deployment-to-vercel
 
 jobs:
   deploy:
@@ -15,33 +16,43 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 21
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
+        uses: actions/setup-node@v4
 
-      - name: Install dependencies
+      - name: Cache node modules
+        id: cache-nodemodules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install Dependencies
+        if: steps.cache-nodemodules.outputs.cache-hit != 'true'
         run: |
-          npm install --dev
+          npm ci
           npm install lerna
           npm install vercel
 
       - name: Build SDKs
+        # currently we have to use build:dev here, because npm run build is not yet working
         run: |
-          npm install
-          lerna run build_and_publish:local
+          npm run build:dev
 
       - name: Deploy react-sdk-example to Vercel
         run: |
           cd playground/react-sdk-example
           npm install
-          npx yalc add @corbado/web-core && npx yalc add @corbado/react-sdk
           npm run build
-          npx vercel deploy --token ${{ secrets.VERCEL_TOKEN }} --prod
+          url="$(npx vercel deploy -t ${{ secrets.VERCEL_TOKEN }})"
+          npx vercel alias -S corbado -t ${{ secrets.VERCEL_TOKEN }} "$url" $BRANCH_NAME.react-sdk.korbado.com
         env:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_REACT_SDK }}
 
@@ -49,8 +60,8 @@ jobs:
         run: |
           cd playground/react-example
           npm install
-          npx yalc add @corbado/web-core && npx yalc add @corbado/react-sdk && npx yalc add @corbado/react
           npm run build
-          npx vercel deploy --token ${{ secrets.VERCEL_TOKEN }} --prod
+          url="$(npx vercel deploy -t ${{ secrets.VERCEL_TOKEN }})"
+          npx vercel alias -S corbado -t ${{ secrets.VERCEL_TOKEN }} "$url" $BRANCH_NAME.react.korbado.com
         env:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_REACT }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26293,33 +26293,6 @@
         "react": ">=18.0.0"
       }
     },
-    "packages/react-sdk/.yalc/@corbado/web-core": {
-      "version": "0.1.6+282e4f12",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@github/webauthn-json": "^2.1.1",
-        "axios": "^1.6.0",
-        "rxjs": "^7.8.1"
-      }
-    },
-    "packages/react/.yalc/@corbado/react-sdk": {
-      "version": "0.1.6+d306d0c4",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@corbado/web-core": "file:.yalc/@corbado/web-core"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "packages/react/.yalc/@corbado/react-sdk/.yalc/@corbado/web-core": {
-      "extraneous": true
-    },
-    "packages/react/.yalc/@corbado/web-core": {
-      "extraneous": true
-    },
     "packages/react/node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
@@ -27582,25 +27555,6 @@
         "typescript": "^5.2.2",
         "vite": "^5.0.0"
       }
-    },
-    "playground/react-sdk-example/.yalc/@corbado/react-sdk": {
-      "version": "0.1.6+5499d14e",
-      "license": "ISC",
-      "dependencies": {
-        "@corbado/web-core": "*"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "playground/react-sdk-example/.yalc/@corbado/web-core": {},
-    "playground/react-sdk-example/node_modules/@corbado/react-sdk": {
-      "resolved": "playground/react-sdk-example/.yalc/@corbado/react-sdk",
-      "link": true
-    },
-    "playground/react-sdk-example/node_modules/@corbado/web-core": {
-      "resolved": "playground/react-sdk-example/.yalc/@corbado/web-core",
-      "link": true
     },
     "playground/react-sdk-example/node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.13.2",


### PR DESCRIPTION
- removed yalc remainings from global package-lock.json
- added caching for node_modules to GitHub action
- enables pull_request events for the action to trigger preview deployments
- set an alias url that includes the branch name for every deployment => this alias can be extracted from the actions logs ("Success! https://branch-name.react.korbado.com now points to ...")
<img width="1141" alt="image" src="https://github.com/corbado/javascript/assets/134682658/4c07cce6-5f07-4762-8066-515e8e433ddb">

So now the creator of a PR and the reviewer can quickly test if our build and the app itself still work by opening https://branch-name.react.korbado.com in a browser.