### PR TITLE
fix incorrect event name for cancel button in signup flow otp page

### DIFF
--- a/packages/shared-ui/src/flowHandler/flows/signup/passkeySignupWithOtpFlow.ts
+++ b/packages/shared-ui/src/flowHandler/flows/signup/passkeySignupWithOtpFlow.ts
@@ -87,7 +87,11 @@ export const PasskeySignupWithEmailOTPFallbackFlow: Flow = {
 
         return FlowUpdate.navigate(ScreenNames.PasskeyAppend);
       }
-      case FlowHandlerEvents.SecondaryButton:
+      case FlowHandlerEvents.SecondaryButton: {
+        // TODO: add OTP resend
+        return undefined;
+      }
+      case FlowHandlerEvents.CancelOTP:
         return FlowUpdate.navigate(ScreenNames.Start);
     }
 


### PR DESCRIPTION
- cancel button now goes to initial signup page as intended
- needs review: The same button in login flow updates email to UserState (check passkeyLoginWithOtpFlow.ts:61). Does this also need to happen in the signup flow?