### PR TITLE
css improvements

### DIFF
--- a/packages/shared-ui/src/styles/index.css
+++ b/packages/shared-ui/src/styles/index.css
@@ -4,7 +4,7 @@
 .cb-container {
   padding: 2.5rem 1.3rem 1.25rem 1.3rem;
   border-radius: 0.5rem;
-  width: 30rem;
+  width: min(30rem, 100%);
   box-sizing: border-box;
   box-shadow: 0 0.5rem 1rem rgb(0 0 0 / 15%);
 }
@@ -475,6 +475,7 @@
   flex-direction: column;
   justify-content: left;
   font-size: 1rem;
+  text-align: left;
   line-height: normal;
   font-weight: 500;
   gap: 0.5rem;


### PR DESCRIPTION
1. Changed the text alignment inside the passkey list to be left aligned. The default left alignment shouldn't be overwritten if the text alignment is set to something else in an element that contains the passkey list.
2. Changed the width of the cb-container class to be the min of 30 rem and 100% instead of just 30rem. The problem was the following. 30rem overflows most mobile devices. Problem with my solution: If the parent container doesn't have some fixed width 100% will just mean that the container takes up as much space as it needs, which might be quite tight.