### PR TITLE
remove timeout for page loads in tests

### DIFF
--- a/packages/tests-e2e/src/utils/constants.ts
+++ b/packages/tests-e2e/src/utils/constants.ts
@@ -14,4 +14,4 @@ export enum OtpType {
   Incorrect = '150918',
 }
 
-export const waitAfterLoad = 600; // remove after repetitive refreshing is fixed
+export const waitAfterLoad = 0; // remove after repetitive refreshing is fixed

--- a/packages/tests-e2e/src/utils/constants.ts
+++ b/packages/tests-e2e/src/utils/constants.ts
@@ -14,4 +14,4 @@ export enum OtpType {
   Incorrect = '150918',
 }
 
-export const waitAfterLoad = 0; // adding a timeout after each page load reduces flakiness (add if flakiness becomes a problem in the pipeline)
+export const waitAfterLoad = 100; // timeout after each page load reduces flakiness (increase if flakiness becomes a problem in the pipeline)

--- a/packages/tests-e2e/src/utils/constants.ts
+++ b/packages/tests-e2e/src/utils/constants.ts
@@ -14,4 +14,4 @@ export enum OtpType {
   Incorrect = '150918',
 }
 
-export const waitAfterLoad = 0; // remove after repetitive refreshing is fixed
+export const waitAfterLoad = 0; // adding a timeout after each page load reduces flakiness (add if flakiness becomes a problem in the pipeline)


### PR DESCRIPTION
- flakiness no longer happens on local
- on pipeline, there is a very small flakiness
- reduced page reload timeout from 600 to 100, seems enough (we can increase it if flakiness becomes a problem in the future)
