### PR TITLE
Improve cookie management (settings from backend are respected)

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -9,7 +9,7 @@ env:
   BRANCH_NAME_RAW: ${{ github.head_ref || github.ref_name }}
 
 on:
-  pull_request:
+  #pull_request:
   push:
     branches:
       # - main

--- a/packages/web-core/src/models/auth.ts
+++ b/packages/web-core/src/models/auth.ts
@@ -1,4 +1,5 @@
 import type { AuthenticationRsp } from '../api';
+import { CookieInfo } from './cookieInfo';
 import { ShortSession } from './session';
 
 export class AuthenticationResponse {
@@ -17,6 +18,10 @@ export class AuthenticationResponse {
       throw new Error('ShortSession is undefined. This must never happen.');
     }
 
-    return new AuthenticationResponse(new ShortSession(value.shortSession.value), value.redirectURL, value.longSession);
+    const s = value.shortSession;
+    const cookieInfo = new CookieInfo(s.value, s.domain, s.expires, s.path, s.sameSite, s.secure);
+    const shortSession = new ShortSession(s.value, cookieInfo);
+
+    return new AuthenticationResponse(shortSession, value.redirectURL, value.longSession);
   }
 }

--- a/packages/web-core/src/models/cookieInfo.ts
+++ b/packages/web-core/src/models/cookieInfo.ts
@@ -1,0 +1,26 @@
+import log from 'loglevel';
+
+export class CookieInfo {
+  value: string;
+  domain: string;
+  expires: string;
+  path: string;
+  sameSite: string;
+  secure: boolean;
+
+  constructor(value: string, domain: string, expires: string, path: string, sameSite: string, secure: boolean) {
+    this.value = value;
+    this.domain = domain;
+    this.expires = expires;
+    this.path = path;
+    this.sameSite = sameSite;
+    this.secure = secure;
+  }
+
+  toCookie(key: string): string {
+    const out = `${key}=${this.value}; path=${this.path}; expires=${this.expires}; domain=${this.domain}; secure=${this.secure}; samesite=${this.sameSite}`;
+    log.info('setting cookie', out);
+
+    return out;
+  }
+}

--- a/packages/web-core/src/models/session.ts
+++ b/packages/web-core/src/models/session.ts
@@ -1,11 +1,15 @@
 import type { SessionUser } from '@corbado/types';
 
+import type { CookieInfo } from './cookieInfo';
+
 export class ShortSession {
   readonly #value: string;
   readonly #user: SessionUser;
+  readonly #cookieInfo?: CookieInfo;
 
-  constructor(value: string) {
+  constructor(value: string, cookieInfo?: CookieInfo) {
     this.#value = value;
+    this.#cookieInfo = cookieInfo;
 
     // this is a quick and easy way to parse JWT tokens without using a library
     const splits = value.split('.');
@@ -18,6 +22,10 @@ export class ShortSession {
 
   get user() {
     return this.#user;
+  }
+
+  get cookieInfo() {
+    return this.#cookieInfo;
   }
 
   isValidForXMoreSeconds(seconds: number): boolean {

--- a/packages/web-core/src/services/ApiService.ts
+++ b/packages/web-core/src/services/ApiService.ts
@@ -6,7 +6,7 @@ import log from 'loglevel';
 import type { Subject } from 'rxjs';
 import { Err, Result } from 'ts-results';
 
-import type { SessionRefreshRsp } from '../api';
+import type { SessionRefreshRsp, ShortSession } from '../api';
 import { AssetsApi, Configuration, ProjectsApi, SessionsApi, UsersApi } from '../api';
 import { AuthenticationResponse } from '../models/auth';
 import type {
@@ -438,6 +438,18 @@ export class ApiService {
       }
 
       return response.data;
+    });
+  }
+
+  public async logout(): Promise<Result<ShortSession | undefined, NonRecoverableError | undefined>> {
+    return Result.wrapAsync(async () => {
+      const response = await this.#sessionsApiWithAuth.sessionLogout({});
+
+      if (response.status !== 200) {
+        return;
+      }
+
+      return response.data.shortSession;
     });
   }
 }

--- a/packages/web-js/src/core/Corbado.ts
+++ b/packages/web-js/src/core/Corbado.ts
@@ -83,7 +83,7 @@ export class Corbado {
       throw new Error('Please call load() before logging out');
     }
 
-    this.#corbadoAppState.logout();
+    return this.#corbadoAppState.logout();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/web-js/src/models/CorbadoAppState.ts
+++ b/packages/web-js/src/models/CorbadoAppState.ts
@@ -86,7 +86,7 @@ export class CorbadoAppState {
       throw new Error('Please call load() before logging out');
     }
 
-    this.corbadoApp.authService.logout();
+    return this.corbadoApp.authService.logout();
   }
 
   clearGlobalError() {


### PR DESCRIPTION
So far we did the cookie management in the client application. The problem with that is that it's very hard to clean up that cookie (to remove the cookie you need to know the path and domain where it has been dropped on) 
=> we now moved the responsibility for managing the cbo_short_session to web-core.
=> client applications no longer need to set or remove the cookie