### PR TITLE
Fix phone textbox locator

### DIFF
--- a/packages/react/src/screens/auth-blocks/login-init/LoginInit.tsx
+++ b/packages/react/src/screens/auth-blocks/login-init/LoginInit.tsx
@@ -74,6 +74,7 @@ export const LoginInit = ({ block }: { block: LoginInitBlock }) => {
         <PhoneInputField
           label={t('textField.phone')}
           labelLink={fieldLink}
+          id='phone'
           autoComplete='tel'
           initialCountry='US'
           initialPhoneNumber={textField?.value}

--- a/packages/tests-e2e/src/ui/b2-01-phoneotp/chromium/PhoneOtp-functionality.spec.ts
+++ b/packages/tests-e2e/src/ui/b2-01-phoneotp/chromium/PhoneOtp-functionality.spec.ts
@@ -17,13 +17,9 @@ test.describe('Login with phone OTP proper user behavior', () => {
     await page.getByText('Log in').click();
     await loginFlow.checkLandedOnScreen(ScreenNames.InitLogin);
 
-    // TODO: why isn't this locator working anymore??
-    // await page.getByRole('textbox', { name: 'phone' }).click();
-    // await page.getByRole('textbox', { name: 'phone' }).fill(phone);
-    // await expect(page.getByRole('textbox', { name: 'phone' })).toHaveValue(new RegExp(`^(\\${phone.slice(0, 2)})?${phone.slice(2)}$`));
-    await page.locator('#phone').click();
-    await page.locator('#phone').fill(phone);
-    await expect(page.locator('#phone')).toHaveValue(new RegExp(`^(\\${phone.slice(0, 2)})?${phone.slice(2)}$`));
+    await page.getByRole('textbox', { name: 'phone' }).click();
+    await page.getByRole('textbox', { name: 'phone' }).fill(phone);
+    await expect(page.getByRole('textbox', { name: 'phone' })).toHaveValue(new RegExp(`^(\\${phone.slice(0, 2)})?${phone.slice(2)}$`));
 
     await page.getByRole('button', { name: 'Continue' }).click();
     await loginFlow.checkLandedOnScreen(ScreenNames.PhoneOtpLogin, undefined, phone);


### PR DESCRIPTION
- added for='phone' attribute to label component
- use 'name' property to locate phone textbox in playwright