### PR TITLE
fix corrupted trace file generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@ playground/*/bundle/
 packages/tests-e2e/test-results
 packages/tests-e2e/playwright-report
 packages/tests-e2e/blob-report
+packages/tests-e2e/all-blob-reports
 packages/tests-e2e/playwright/.cach/

--- a/packages/tests-e2e/playwright.config.ui.ts
+++ b/packages/tests-e2e/playwright.config.ui.ts
@@ -26,13 +26,14 @@ export default defineConfig({
       : undefined
     : undefined,
   // reporter: 'html',
+  // reporter: 'blob',
   reporter: [
     [
       'blob',
       {
         // Saving all blobs to the same directory deletes every other blob in the directory
         // so we temporarily make a directory for each project (ref: run-all-projects.sh)
-        outputDir: `playwright-report/${process.env.PLAYWRIGHT_PROJECT_NAME}`,
+        outputDir: `blob-report/${process.env.PLAYWRIGHT_PROJECT_NAME}`,
         fileName: `report-${process.env.PLAYWRIGHT_PROJECT_NAME}.zip`,
       },
     ],
@@ -45,7 +46,7 @@ export default defineConfig({
     actionTimeout: 3000, // default: none
     navigationTimeout: 3000, // default: none
     baseURL: `${process.env.PLAYWRIGHT_TEST_URL}/${process.env.PLAYWRIGHT_PROJECT_ID}`,
-    trace: 'on-first-retry',
+    trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
   },
   projects: [

--- a/packages/tests-e2e/playwright.config.ui.ts
+++ b/packages/tests-e2e/playwright.config.ui.ts
@@ -26,7 +26,6 @@ export default defineConfig({
       : undefined
     : undefined,
   // reporter: 'html',
-  // reporter: 'blob',
   reporter: [
     [
       'blob',

--- a/packages/tests-e2e/run-all-projects.sh
+++ b/packages/tests-e2e/run-all-projects.sh
@@ -3,14 +3,14 @@
 project_names=(
   "b1-01-emailotp-chromium"
   "b1-01-phoneotp-chromium"
-  # "b1-01-emaillink-chromium"
-  # "b1-02-chromium"
-  # "b1-03-all-browsers"
-  # "b1-11-chromium"
-  # "b2-01-emailotp-chromium"
-  # "b2-01-phoneotp-chromium"
-  # "b2-01-emaillink-chromium"
-  # "b2-03-all-browsers"
+  "b1-01-emaillink-chromium"
+  "b1-02-chromium"
+  "b1-03-all-browsers"
+  "b1-11-chromium"
+  "b2-01-emailotp-chromium"
+  "b2-01-phoneotp-chromium"
+  "b2-01-emaillink-chromium"
+  "b2-03-all-browsers"
 )
 
 mkdir all-blob-reports

--- a/packages/tests-e2e/run-all-projects.sh
+++ b/packages/tests-e2e/run-all-projects.sh
@@ -3,21 +3,22 @@
 project_names=(
   "b1-01-emailotp-chromium"
   "b1-01-phoneotp-chromium"
-  "b1-01-emaillink-chromium"
-  "b1-02-chromium"
-  "b1-03-all-browsers"
-  "b1-11-chromium"
-  "b2-01-emailotp-chromium"
-  "b2-01-phoneotp-chromium"
-  "b2-01-emaillink-chromium"
-  "b2-03-all-browsers"
+  # "b1-01-emaillink-chromium"
+  # "b1-02-chromium"
+  # "b1-03-all-browsers"
+  # "b1-11-chromium"
+  # "b2-01-emailotp-chromium"
+  # "b2-01-phoneotp-chromium"
+  # "b2-01-emaillink-chromium"
+  # "b2-03-all-browsers"
 )
 
+mkdir all-blob-reports
 for project_name in "${project_names[@]}"; do
   PW_TEST_HTML_REPORT_OPEN='never' PLAYWRIGHT_PROJECT_NAME=$project_name playwright test --config=playwright.config.ui.ts --project=$project_name || EXIT=$?
-  mv playwright-report/$project_name/* playwright-report/
+  cp blob-report/$project_name/* all-blob-reports/
 done
 
-playwright merge-reports --reporter html playwright-report/
+playwright merge-reports --reporter html all-blob-reports/
 
 exit $EXIT

--- a/packages/tests-e2e/src/ui/b1-01-emailotp/all-browsers/EmailOtp-functionality.spec.ts
+++ b/packages/tests-e2e/src/ui/b1-01-emailotp/all-browsers/EmailOtp-functionality.spec.ts
@@ -10,7 +10,5 @@ test.describe('Signup with email OTP proper user behavior', () => {
     await signupFlow.fillOTP(OtpType.Email);
     await signupFlow.checkLandedOnScreen(ScreenNames.End);
     await signupFlow.checkNoPasskeyRegistered();
-
-    await signupFlow.checkPasskeyRegistered();
   });
 });

--- a/packages/tests-e2e/src/ui/b1-01-emailotp/all-browsers/EmailOtp-functionality.spec.ts
+++ b/packages/tests-e2e/src/ui/b1-01-emailotp/all-browsers/EmailOtp-functionality.spec.ts
@@ -10,5 +10,7 @@ test.describe('Signup with email OTP proper user behavior', () => {
     await signupFlow.fillOTP(OtpType.Email);
     await signupFlow.checkLandedOnScreen(ScreenNames.End);
     await signupFlow.checkNoPasskeyRegistered();
+
+    await signupFlow.checkPasskeyRegistered();
   });
 });


### PR DESCRIPTION
Apparently creating blobs in ./playwright-report and then merging them into the same directory (./playwright-report) will generate corrupt trace files.

Solution was to use one directory for blob generation (./blob-report), and a separate directory for merging reports (./playwright-report), after which trace files will be usable

Also turned on trace files for all failed tests (originally only for 1st retry).
- on-first-retry option only records for 1st retry
- retain-on-failure records for every test, and then deletes for successful tests. This is apparently not recommended because it will take significantly longer than on-first-retry. If it takes too long, we can disable later