### PR TITLE
prevent user select on container-body

### DIFF
--- a/packages/shared-ui/src/styles/index.css
+++ b/packages/shared-ui/src/styles/index.css
@@ -19,6 +19,7 @@
   display: flex;
   flex-direction: column;
   padding: 0.5rem 1.5rem;
+  user-select: none;
 }
 
 .cb-form {


### PR DESCRIPTION
When logging in, focus drops into the container-body, thus the cursor blinks next to the title, watch "Log in":

https://github.com/corbado/javascript/assets/669783/e74a34a4-b5e9-4dbb-9ab6-04fa644b885b

I find this distracting. This pull request prevents that by preventing user-selection:

https://github.com/corbado/javascript/assets/669783/b837d515-688e-41f0-b943-4fdacf83af2c

