### PR TITLE
Add slack notifications to nightly tests

### DIFF
--- a/.github/workflows/e2e-test-commitly.yml
+++ b/.github/workflows/e2e-test-commitly.yml
@@ -108,7 +108,6 @@ jobs:
           PLAYWRIGHT_MICROSOFT_EMAIL: ${{ secrets.PLAYWRIGHT_MICROSOFT_EMAIL }}
           PLAYWRIGHT_MICROSOFT_PASSWORD: ${{ secrets.PLAYWRIGHT_MICROSOFT_PASSWORD }}
           GITHUB_RUN_ID: ${{ github.run_id }}
-          SLACK_BOT_USER_OAUTH_TOKEN: ${{ secrets.SLACK_BOT_USER_OAUTH_TOKEN }}
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/e2e-test-commitly.yml
+++ b/.github/workflows/e2e-test-commitly.yml
@@ -108,6 +108,7 @@ jobs:
           PLAYWRIGHT_MICROSOFT_EMAIL: ${{ secrets.PLAYWRIGHT_MICROSOFT_EMAIL }}
           PLAYWRIGHT_MICROSOFT_PASSWORD: ${{ secrets.PLAYWRIGHT_MICROSOFT_PASSWORD }}
           GITHUB_RUN_ID: ${{ github.run_id }}
+          SLACK_BOT_USER_OAUTH_TOKEN: ${{ secrets.SLACK_BOT_USER_OAUTH_TOKEN }}
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/e2e-test-nightly.yml
+++ b/.github/workflows/e2e-test-nightly.yml
@@ -91,7 +91,6 @@ jobs:
           npx playwright install --with-deps
 
       - name: Run E2E Test for ${{ matrix.app }}
-        # id: playwright
         run: |
           if [ "${{ matrix.type }}" = "sdk" ]; then
             npm run test:e2e:sdk
@@ -106,16 +105,6 @@ jobs:
           PLAYWRIGHT_MICROSOFT_PASSWORD: ${{ secrets.PLAYWRIGHT_MICROSOFT_PASSWORD }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           SLACK_BOT_USER_OAUTH_TOKEN: ${{ secrets.SLACK_BOT_USER_OAUTH_TOKEN }}
-      # - name: Post to a Slack channel
-      #   if: always() && steps.playwright.outcome == 'failure'
-      #   id: slack
-      #   uses: slackapi/slack-github-action@v1.26.0
-      #   with:
-      #     # corbado-frontend, corbado-backend
-      #     channel-id: 'C05TA800TGB,C06T8GL6T46'
-      #     slack-message: "Nightly test failed: ${{ job.status }}"
-      #   env:
-      #     SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/e2e-test-nightly.yml
+++ b/.github/workflows/e2e-test-nightly.yml
@@ -91,6 +91,7 @@ jobs:
           npx playwright install --with-deps
 
       - name: Run E2E Test for ${{ matrix.app }}
+        # id: playwright
         run: |
           if [ "${{ matrix.type }}" = "sdk" ]; then
             npm run test:e2e:sdk
@@ -104,6 +105,17 @@ jobs:
           PLAYWRIGHT_MICROSOFT_EMAIL: ${{ secrets.PLAYWRIGHT_MICROSOFT_EMAIL }}
           PLAYWRIGHT_MICROSOFT_PASSWORD: ${{ secrets.PLAYWRIGHT_MICROSOFT_PASSWORD }}
           GITHUB_RUN_ID: ${{ github.run_id }}
+          SLACK_BOT_USER_OAUTH_TOKEN: ${{ secrets.SLACK_BOT_USER_OAUTH_TOKEN }}
+      # - name: Post to a Slack channel
+      #   if: always() && steps.playwright.outcome == 'failure'
+      #   id: slack
+      #   uses: slackapi/slack-github-action@v1.26.0
+      #   with:
+      #     # corbado-frontend, corbado-backend
+      #     channel-id: 'C05TA800TGB,C06T8GL6T46'
+      #     slack-message: "Nightly test failed: ${{ job.status }}"
+      #   env:
+      #     SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5021,6 +5021,96 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@slack/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": ">=12.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.11.0.tgz",
+      "integrity": "sha512-UlIrDWvuLaDly3QZhCPnwUSI/KYmV1N9LyhuH6EDKCRS1HWZhyTG3Ja46T3D0rYfqdltKYFXbJSSRPwZpwO0cQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.12.0.tgz",
+      "integrity": "sha512-RPw6F8rWfGveGkZEJ4+4jUin5iazxRK2q3FpQDz/FvdgzC3nZmPyLx8WRzc6nh0w3MBjEbphNnp2VZksfhpBIQ==",
+      "dev": true,
+      "dependencies": {
+        "@slack/logger": "^3.0.0",
+        "@slack/types": "^2.11.0",
+        "@types/is-stream": "^1.1.0",
+        "@types/node": ">=12.0.0",
+        "axios": "^1.6.5",
+        "eventemitter3": "^3.1.0",
+        "form-data": "^2.5.0",
+        "is-electron": "2.2.2",
+        "is-stream": "^1.1.0",
+        "p-queue": "^6.6.1",
+        "p-retry": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "dev": true
+    },
+    "node_modules/@slack/web-api/node_modules/form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@slack/webhook": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@slack/webhook/-/webhook-7.0.2.tgz",
+      "integrity": "sha512-dsrO/ow6a6+xkLm/lZKbUNTsFJlBc679tD+qwlVTztsQkDxPLH6odM7FKALz1IHa+KpLX8HKUIPV13a7y7z29w==",
+      "dev": true,
+      "dependencies": {
+        "@slack/types": "^2.9.0",
+        "@types/node": ">=18.0.0",
+        "axios": "^1.6.3"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -5920,6 +6010,15 @@
       "version": "1.17.14",
       "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.14.tgz",
       "integrity": "sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -15465,6 +15564,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "dev": true
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -21149,6 +21254,57 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/playwright-slack-report": {
+      "version": "1.1.72",
+      "resolved": "https://registry.npmjs.org/playwright-slack-report/-/playwright-slack-report-1.1.72.tgz",
+      "integrity": "sha512-Gt7Uyzn+SPQQniRCX7qAqOtgmU7rqF5HyM+laZ+1Drsl99xEqA6nyp0da/nqqORrJMnQLkgvGMtbXHIveBCPaQ==",
+      "dev": true,
+      "dependencies": {
+        "@slack/web-api": "^6.9.1",
+        "@slack/webhook": "^7.0.1",
+        "commander": "^11.1.0",
+        "https-proxy-agent": "^7.0.1",
+        "ts-node": "^10.9.1",
+        "zod": "^3.22.4"
+      },
+      "bin": {
+        "playwright-slack-report": "dist/cli.js"
+      }
+    },
+    "node_modules/playwright-slack-report/node_modules/agent-base": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/playwright-slack-report/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/playwright-slack-report/node_modules/https-proxy-agent": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/pm2": {
@@ -28681,6 +28837,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "packages/react": {
       "name": "@corbado/react",
       "version": "2.7.0",
@@ -29549,7 +29714,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@types/node": "^20.10.5"
+        "@types/node": "^20.10.5",
+        "playwright-slack-report": "^1.1.72"
       }
     },
     "packages/types": {

--- a/packages/tests-e2e/README.md
+++ b/packages/tests-e2e/README.md
@@ -31,19 +31,19 @@ Now Playwright is ready to test the local Playground deployment.
 
 ```console
 $ cd packages/tests-e2e
-$ npx playwright test --config=playwright.config.ui.ts --ui
+$ npx playwright test --config=playwright.config.ui.ts --ui --project=nightly
 ```
 
 ### From CLI
 
 ```console
-npx playwright test --config=playwright.config.ui.ts
+npx playwright test --config=playwright.config.ui.ts --project=nightly
 ```
 
 Alternatively, you can do:
 
 ```console
-npm run e2e:ui
+npm run e2e:ui:nightly
 ```
 
 ## Generating JWT Token

--- a/packages/tests-e2e/package.json
+++ b/packages/tests-e2e/package.json
@@ -21,6 +21,7 @@
     "url": "https://github.com/corbado/javascript/issues"
   },
   "devDependencies": {
-    "@types/node": "^20.10.5"
+    "@types/node": "^20.10.5",
+    "playwright-slack-report": "^1.1.72"
   }
 }

--- a/packages/tests-e2e/playwright.config.ui.ts
+++ b/packages/tests-e2e/playwright.config.ui.ts
@@ -34,6 +34,7 @@ export default defineConfig({
         channels: ['corbado-javascript-tests'],
         sendResults: 'always',
         showInThread: true,
+        disableUnfurl: true,
         meta: [
           {
             key: 'Test Run Info',

--- a/packages/tests-e2e/playwright.config.ui.ts
+++ b/packages/tests-e2e/playwright.config.ui.ts
@@ -34,7 +34,7 @@ export default defineConfig({
         channels: ['corbado-javascript-tests'],
         sendResults: 'always',
         showInThread: true,
-        disableUnfurl: true,
+        disableUnfurl: false,
         meta: [
           {
             key: 'Test Run Info',

--- a/packages/tests-e2e/playwright.config.ui.ts
+++ b/packages/tests-e2e/playwright.config.ui.ts
@@ -27,7 +27,17 @@ export default defineConfig({
       ? parseInt(process.env.PLAYWRIGHT_NUM_CORES, 10) - 1
       : undefined
     : undefined,
-  reporter: 'html',
+  reporter: [
+    [
+      './node_modules/playwright-slack-report/dist/src/SlackReporter.js',
+      {
+        channels: ['corbado-javascript-tests'],
+        sendResults: 'on-failure',
+        maxNumberOfFailuresToShow: 4,
+      }
+    ],
+    ['html'],
+  ],
   timeout: totalTimeout, // default: 30000ms
   expect: {
     timeout: operationTimeout, // default: 5000ms

--- a/packages/tests-e2e/playwright.config.ui.ts
+++ b/packages/tests-e2e/playwright.config.ui.ts
@@ -32,7 +32,7 @@ export default defineConfig({
       './node_modules/playwright-slack-report/dist/src/SlackReporter.js',
       {
         channels: ['corbado-javascript-tests'],
-        sendResults: 'on-failure',
+        sendResults: 'always',
         maxNumberOfFailuresToShow: 4,
       }
     ],

--- a/packages/tests-e2e/playwright.config.ui.ts
+++ b/packages/tests-e2e/playwright.config.ui.ts
@@ -32,7 +32,7 @@ export default defineConfig({
       '../../node_modules/playwright-slack-report/dist/src/SlackReporter.js',
       {
         channels: ['corbado-javascript-tests'],
-        sendResults: 'on-failure',
+        sendResults: 'always',
         showInThread: true,
         meta: [
           {

--- a/packages/tests-e2e/playwright.config.ui.ts
+++ b/packages/tests-e2e/playwright.config.ui.ts
@@ -32,7 +32,7 @@ export default defineConfig({
       '../../node_modules/playwright-slack-report/dist/src/SlackReporter.js',
       {
         channels: ['corbado-javascript-tests'],
-        sendResults: 'always',
+        sendResults: 'on-failure',
         showInThread: true,
         meta: [
           {

--- a/packages/tests-e2e/playwright.config.ui.ts
+++ b/packages/tests-e2e/playwright.config.ui.ts
@@ -29,12 +29,18 @@ export default defineConfig({
     : undefined,
   reporter: [
     [
-      './node_modules/playwright-slack-report/dist/src/SlackReporter.js',
+      '../../node_modules/playwright-slack-report/dist/src/SlackReporter.js',
       {
         channels: ['corbado-javascript-tests'],
         sendResults: 'always',
-        maxNumberOfFailuresToShow: 4,
-      }
+        showInThread: true,
+        meta: [
+          {
+            key: 'Test Run Info',
+            value: `https://github.com/corbado/javascript/actions/runs/${process.env.GITHUB_RUN_ID}`,
+          },
+        ],
+      },
     ],
     ['html'],
   ],

--- a/packages/tests-e2e/playwright.config.ui.ts
+++ b/packages/tests-e2e/playwright.config.ui.ts
@@ -34,7 +34,6 @@ export default defineConfig({
         channels: ['corbado-javascript-tests'],
         sendResults: 'always',
         showInThread: true,
-        disableUnfurl: false,
         meta: [
           {
             key: 'Test Run Info',


### PR DESCRIPTION
Posts a message to `corbado_javascript_tests` channel for every nightly run
- Includes a link to the github workflow to facilitate downloading test report