### PR TITLE
Hide error in CorbadoConnectPasskeyList if delete is started

### DIFF
--- a/packages/connect-react/src/components/passkeyList/PasskeyListScreen.tsx
+++ b/packages/connect-react/src/components/passkeyList/PasskeyListScreen.tsx
@@ -262,6 +262,7 @@ const PasskeyListScreen = () => {
     <PasskeyList
       passkeys={passkeyList}
       onDeleteClick={passkey => {
+        setHardErrorMessage(null);
         show(DeleteModalContent(passkey));
       }}
       isLoading={loading}


### PR DESCRIPTION
Makes sure that we remove a top-error once a new delete is initiated