### PR TITLE
Adds config option to disable auto focus of fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7984,6 +7984,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/crypto-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
+      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/debounce": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/debounce/-/debounce-1.2.4.tgz",
@@ -11602,6 +11609,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
@@ -17827,6 +17840,15 @@
       "engines": {
         "node": ">=12",
         "npm": ">=6"
+      }
+    },
+    "node_modules/jssha": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jssha/-/jssha-3.3.1.tgz",
+      "integrity": "sha512-VCMZj12FCFMQYcFLPRm/0lOBbLi8uM2BhXPTqw3U4YAfs4AZfiApOoBLoN8cQE60Z50m1MYMTQVCfgF/KaCVhQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -25120,6 +25142,15 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/totp-generator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/totp-generator/-/totp-generator-1.0.0.tgz",
+      "integrity": "sha512-Iu/1Lk60/MH8FE+5cDWPiGbwKK1hxzSq+KT9oSqhZ1BEczGIKGcN50bP0WMLiIZKRg7t29iWLxw6f81TICQdoA==",
+      "license": "MIT",
+      "dependencies": {
+        "jssha": "^3.3.1"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "4.1.3",
       "license": "BSD-3-Clause",
@@ -27226,14 +27257,17 @@
         "@corbado/connect-react": "*",
         "aws-sdk": "^2.1646.0",
         "axios": "^1.7.3",
+        "crypto-js": "^4.2.0",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.1.0",
         "next": "14.2.4",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "totp-generator": "^1.0.0"
       },
       "devDependencies": {
         "@tailwindcss/forms": "^0.5.7",
+        "@types/crypto-js": "^4.2.2",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",

--- a/packages/react/src/components/authentication/AuthFlow.tsx
+++ b/packages/react/src/components/authentication/AuthFlow.tsx
@@ -40,7 +40,11 @@ import ErrorPopup from '../ui/errors/ErrorPopup';
 import { FreemiumBadge } from '../ui/FreemiumBadge';
 import { LoadingSpinner } from '../ui/LoadingSpinner';
 
-export const AuthFlow: FC = () => {
+type Props = {
+  autoFocus: boolean;
+};
+
+export const AuthFlow: FC<Props> = ({ autoFocus }) => {
   const { isDevMode, customerSupportEmail } = useErrorHandling();
   const { currentScreen, initState } = useFlowHandler();
   const [loading, setLoading] = useState(false);
@@ -74,9 +78,19 @@ export const AuthFlow: FC = () => {
 
     switch (currentScreen.block.type) {
       case BlockTypes.LoginInit:
-        return <LoginInit block={currentScreen.block as LoginInitBlock} />;
+        return (
+          <LoginInit
+            block={currentScreen.block as LoginInitBlock}
+            autoFocus={autoFocus}
+          />
+        );
       case BlockTypes.SignupInit:
-        return <SignupInit block={currentScreen.block as SignupInitBlock} />;
+        return (
+          <SignupInit
+            block={currentScreen.block as SignupInitBlock}
+            autoFocus={autoFocus}
+          />
+        );
       case BlockTypes.EmailVerify:
         switch (currentScreen.screen) {
           case ScreenNames.EmailLinkSent:

--- a/packages/react/src/components/authentication/AuthFlow.tsx
+++ b/packages/react/src/components/authentication/AuthFlow.tsx
@@ -41,10 +41,10 @@ import { FreemiumBadge } from '../ui/FreemiumBadge';
 import { LoadingSpinner } from '../ui/LoadingSpinner';
 
 type Props = {
-  autoFocus: boolean;
+  initialAutoFocus: boolean;
 };
 
-export const AuthFlow: FC<Props> = ({ autoFocus }) => {
+export const AuthFlow: FC<Props> = ({ initialAutoFocus }) => {
   const { isDevMode, customerSupportEmail } = useErrorHandling();
   const { currentScreen, initState } = useFlowHandler();
   const [loading, setLoading] = useState(false);
@@ -81,14 +81,14 @@ export const AuthFlow: FC<Props> = ({ autoFocus }) => {
         return (
           <LoginInit
             block={currentScreen.block as LoginInitBlock}
-            autoFocus={autoFocus}
+            autoFocus={initialAutoFocus}
           />
         );
       case BlockTypes.SignupInit:
         return (
           <SignupInit
             block={currentScreen.block as SignupInitBlock}
-            autoFocus={autoFocus}
+            autoFocus={initialAutoFocus}
           />
         );
       case BlockTypes.EmailVerify:

--- a/packages/react/src/components/authentication/AuthFlow.tsx
+++ b/packages/react/src/components/authentication/AuthFlow.tsx
@@ -81,14 +81,14 @@ export const AuthFlow: FC<Props> = ({ initialAutoFocus }) => {
         return (
           <LoginInit
             block={currentScreen.block as LoginInitBlock}
-            autoFocus={initialAutoFocus}
+            initialAutoFocus={initialAutoFocus}
           />
         );
       case BlockTypes.SignupInit:
         return (
           <SignupInit
             block={currentScreen.block as SignupInitBlock}
-            autoFocus={initialAutoFocus}
+            initialAutoFocus={initialAutoFocus}
           />
         );
       case BlockTypes.EmailVerify:

--- a/packages/react/src/components/authentication/login-init/LoginForm.tsx
+++ b/packages/react/src/components/authentication/login-init/LoginForm.tsx
@@ -14,7 +14,13 @@ export interface LoginFormProps {
   initialAutoFocus: boolean;
 }
 
-export const LoginForm: FC<LoginFormProps> = ({ block, loading, socialLoadingInProgress, setLoading, initialAutoFocus }) => {
+export const LoginForm: FC<LoginFormProps> = ({
+  block,
+  loading,
+  socialLoadingInProgress,
+  setLoading,
+  initialAutoFocus,
+}) => {
   const { t } = useTranslation('translation', { keyPrefix: `login.login-init.login-init` });
 
   const [textField, setTextField] = useState<TextFieldWithError | null>(null);

--- a/packages/react/src/components/authentication/login-init/LoginForm.tsx
+++ b/packages/react/src/components/authentication/login-init/LoginForm.tsx
@@ -11,10 +11,10 @@ export interface LoginFormProps {
   socialLoadingInProgress: boolean | undefined;
   loading: boolean;
   setLoading: (loading: boolean) => void;
-  autoFocus: boolean;
+  initialAutoFocus: boolean;
 }
 
-export const LoginForm: FC<LoginFormProps> = ({ block, loading, socialLoadingInProgress, setLoading, autoFocus }) => {
+export const LoginForm: FC<LoginFormProps> = ({ block, loading, socialLoadingInProgress, setLoading, initialAutoFocus }) => {
   const { t } = useTranslation('translation', { keyPrefix: `login.login-init.login-init` });
 
   const [textField, setTextField] = useState<TextFieldWithError | null>(null);
@@ -37,7 +37,7 @@ export const LoginForm: FC<LoginFormProps> = ({ block, loading, socialLoadingInP
     if (!textFieldRef.current) {
       return;
     }
-    if (autoFocus) {
+    if (initialAutoFocus) {
       textFieldRef.current.focus();
     }
     textFieldRef.current.value = block.data.loginIdentifier ? block.data.loginIdentifier : '';
@@ -77,7 +77,7 @@ export const LoginForm: FC<LoginFormProps> = ({ block, loading, socialLoadingInP
           initialCountry='US'
           initialPhoneNumber={textField?.value}
           errorMessage={textField?.translatedError}
-          autoFocus={autoFocus}
+          autoFocus={initialAutoFocus}
           onChange={setPhoneInput}
         />
       );
@@ -98,7 +98,7 @@ export const LoginForm: FC<LoginFormProps> = ({ block, loading, socialLoadingInP
           name='username'
           type='username'
           autoComplete='username webauthn'
-          autoFocus={autoFocus}
+          autoFocus={initialAutoFocus}
           {...commonProps}
         />
       );
@@ -112,7 +112,7 @@ export const LoginForm: FC<LoginFormProps> = ({ block, loading, socialLoadingInP
         name='email'
         type='email'
         autoComplete='username webauthn'
-        autoFocus={autoFocus}
+        autoFocus={initialAutoFocus}
         {...commonProps}
       />
     );

--- a/packages/react/src/components/authentication/login-init/LoginForm.tsx
+++ b/packages/react/src/components/authentication/login-init/LoginForm.tsx
@@ -11,9 +11,10 @@ export interface LoginFormProps {
   socialLoadingInProgress: boolean | undefined;
   loading: boolean;
   setLoading: (loading: boolean) => void;
+  autoFocus: boolean;
 }
 
-export const LoginForm: FC<LoginFormProps> = ({ block, loading, socialLoadingInProgress, setLoading }) => {
+export const LoginForm: FC<LoginFormProps> = ({ block, loading, socialLoadingInProgress, setLoading, autoFocus }) => {
   const { t } = useTranslation('translation', { keyPrefix: `login.login-init.login-init` });
 
   const [textField, setTextField] = useState<TextFieldWithError | null>(null);
@@ -33,10 +34,13 @@ export const LoginForm: FC<LoginFormProps> = ({ block, loading, socialLoadingInP
 
     setTextField({ value: block.data.loginIdentifier, translatedError: block.data.loginIdentifierError });
 
-    if (textFieldRef.current) {
-      textFieldRef.current.focus();
-      textFieldRef.current.value = block.data.loginIdentifier ? block.data.loginIdentifier : '';
+    if (!textFieldRef.current) {
+      return;
     }
+    if (autoFocus) {
+      textFieldRef.current.focus();
+    }
+    textFieldRef.current.value = block.data.loginIdentifier ? block.data.loginIdentifier : '';
   }, [block]);
 
   const submitButtonText = useMemo(() => t('button_submit'), [t]);
@@ -73,7 +77,7 @@ export const LoginForm: FC<LoginFormProps> = ({ block, loading, socialLoadingInP
           initialCountry='US'
           initialPhoneNumber={textField?.value}
           errorMessage={textField?.translatedError}
-          autoFocus={true}
+          autoFocus={autoFocus}
           onChange={setPhoneInput}
         />
       );
@@ -94,7 +98,7 @@ export const LoginForm: FC<LoginFormProps> = ({ block, loading, socialLoadingInP
           name='username'
           type='username'
           autoComplete='username webauthn'
-          autoFocus={true}
+          autoFocus={autoFocus}
           {...commonProps}
         />
       );
@@ -108,7 +112,7 @@ export const LoginForm: FC<LoginFormProps> = ({ block, loading, socialLoadingInP
         name='email'
         type='email'
         autoComplete='username webauthn'
-        autoFocus={true}
+        autoFocus={autoFocus}
         {...commonProps}
       />
     );

--- a/packages/react/src/screens/auth-blocks/login-init/LoginInit.tsx
+++ b/packages/react/src/screens/auth-blocks/login-init/LoginInit.tsx
@@ -8,7 +8,7 @@ import { Header, SecondaryButton, SocialLoginButtons, SubHeader, Text } from '..
 import { LastIdentifier } from '../../../components/authentication/login-init/LastIdentifier';
 import { LoginForm } from '../../../components/authentication/login-init/LoginForm';
 
-export const LoginInit = ({ block, autoFocus }: { block: LoginInitBlock; autoFocus: boolean }) => {
+export const LoginInit = ({ block, initialAutoFocus }: { block: LoginInitBlock; initialAutoFocus: boolean }) => {
   const { t } = useTranslation('translation', { keyPrefix: `login.login-init.login-init` });
   const [loading, setLoading] = useState<boolean>(false);
   const [socialLoadingInProgress, setSocialLoadingInProgress] = useState<boolean | undefined>(undefined);
@@ -105,7 +105,7 @@ export const LoginInit = ({ block, autoFocus }: { block: LoginInitBlock; autoFoc
           loading={loading}
           socialLoadingInProgress={socialLoadingInProgress}
           setLoading={setLoading}
-          autoFocus={autoFocus}
+          initialAutoFocus={initialAutoFocus}
         />
       )}
       <SocialLoginButtons

--- a/packages/react/src/screens/auth-blocks/login-init/LoginInit.tsx
+++ b/packages/react/src/screens/auth-blocks/login-init/LoginInit.tsx
@@ -8,7 +8,7 @@ import { Header, SecondaryButton, SocialLoginButtons, SubHeader, Text } from '..
 import { LastIdentifier } from '../../../components/authentication/login-init/LastIdentifier';
 import { LoginForm } from '../../../components/authentication/login-init/LoginForm';
 
-export const LoginInit = ({ block }: { block: LoginInitBlock }) => {
+export const LoginInit = ({ block, autoFocus }: { block: LoginInitBlock; autoFocus: boolean }) => {
   const { t } = useTranslation('translation', { keyPrefix: `login.login-init.login-init` });
   const [loading, setLoading] = useState<boolean>(false);
   const [socialLoadingInProgress, setSocialLoadingInProgress] = useState<boolean | undefined>(undefined);
@@ -105,6 +105,7 @@ export const LoginInit = ({ block }: { block: LoginInitBlock }) => {
           loading={loading}
           socialLoadingInProgress={socialLoadingInProgress}
           setLoading={setLoading}
+          autoFocus={autoFocus}
         />
       )}
       <SocialLoginButtons

--- a/packages/react/src/screens/auth-blocks/signup-init/SignupInit.tsx
+++ b/packages/react/src/screens/auth-blocks/signup-init/SignupInit.tsx
@@ -13,7 +13,7 @@ import { Header } from '../../../components/ui/typography/Header';
 import { SubHeader } from '../../../components/ui/typography/SubHeader';
 import { Text } from '../../../components/ui/typography/Text';
 
-export const SignupInit = ({ block, autoFocus }: { block: SignupInitBlock; autoFocus: boolean }) => {
+export const SignupInit = ({ block, initialAutoFocus }: { block: SignupInitBlock; initialAutoFocus: boolean }) => {
   const { t } = useTranslation('translation', { keyPrefix: `signup.signup-init.signup-init` });
 
   const [loading, setLoading] = useState<boolean>(false);
@@ -81,7 +81,7 @@ export const SignupInit = ({ block, autoFocus }: { block: SignupInitBlock; autoF
         ref.current.value = value || '';
       }
 
-      if (!hasFocusField.current && autoFocus) {
+      if (!hasFocusField.current && initialAutoFocus) {
         ref.current.focus();
         hasFocusField.current = true;
       }
@@ -97,7 +97,7 @@ export const SignupInit = ({ block, autoFocus }: { block: SignupInitBlock; autoF
   const userName = block.data.userName;
   const email = block.data.email;
   const phone = block.data.phone;
-  const foucsPhoneField = !!(phone && !email && !userName && !fullName) && autoFocus;
+  const foucsPhoneField = !!(phone && !email && !userName && !fullName) && initialAutoFocus;
 
   if (foucsPhoneField) {
     hasFocusField.current = true;

--- a/packages/react/src/screens/auth-blocks/signup-init/SignupInit.tsx
+++ b/packages/react/src/screens/auth-blocks/signup-init/SignupInit.tsx
@@ -1,8 +1,7 @@
 import type { LoginIdentifiers, SignupInitBlock } from '@corbado/shared-ui';
 import type { SocialProviderType } from '@corbado/web-core';
 import type { FormEvent, MutableRefObject } from 'react';
-import { useEffect } from 'react';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { PrimaryButton } from '../../../components/ui/buttons/PrimaryButton';
@@ -14,7 +13,7 @@ import { Header } from '../../../components/ui/typography/Header';
 import { SubHeader } from '../../../components/ui/typography/SubHeader';
 import { Text } from '../../../components/ui/typography/Text';
 
-export const SignupInit = ({ block }: { block: SignupInitBlock }) => {
+export const SignupInit = ({ block, autoFocus }: { block: SignupInitBlock; autoFocus: boolean }) => {
   const { t } = useTranslation('translation', { keyPrefix: `signup.signup-init.signup-init` });
 
   const [loading, setLoading] = useState<boolean>(false);
@@ -82,7 +81,7 @@ export const SignupInit = ({ block }: { block: SignupInitBlock }) => {
         ref.current.value = value || '';
       }
 
-      if (!hasFocusField.current) {
+      if (!hasFocusField.current && autoFocus) {
         ref.current.focus();
         hasFocusField.current = true;
       }
@@ -98,7 +97,7 @@ export const SignupInit = ({ block }: { block: SignupInitBlock }) => {
   const userName = block.data.userName;
   const email = block.data.email;
   const phone = block.data.phone;
-  const foucsPhoneField = !!(phone && !email && !userName && !fullName);
+  const foucsPhoneField = !!(phone && !email && !userName && !fullName) && autoFocus;
 
   if (foucsPhoneField) {
     hasFocusField.current = true;

--- a/packages/react/src/screens/core/CorbadoAuth.tsx
+++ b/packages/react/src/screens/core/CorbadoAuth.tsx
@@ -6,14 +6,14 @@ import React from 'react';
 import { AuthFlow } from '../../components';
 import FlowHandlerProvider from '../../contexts/FlowHandlerProvider';
 
-const CorbadoAuth: FC<CorbadoAuthConfig> = ({ onLoggedIn, handleNavigationEvents, initialBlock, autoFocus = true }) => {
+const CorbadoAuth: FC<CorbadoAuthConfig> = ({ onLoggedIn, handleNavigationEvents, initialBlock, initialAutoFocus = true }) => {
   return (
     <FlowHandlerProvider
       onLoggedIn={onLoggedIn}
       handleNavigationEvents={handleNavigationEvents}
       initialBlock={initialBlock as BlockTypes}
     >
-      <AuthFlow autoFocus={autoFocus} />
+      <AuthFlow initialAutoFocus={initialAutoFocus} />
     </FlowHandlerProvider>
   );
 };

--- a/packages/react/src/screens/core/CorbadoAuth.tsx
+++ b/packages/react/src/screens/core/CorbadoAuth.tsx
@@ -6,14 +6,14 @@ import React from 'react';
 import { AuthFlow } from '../../components';
 import FlowHandlerProvider from '../../contexts/FlowHandlerProvider';
 
-const CorbadoAuth: FC<CorbadoAuthConfig> = ({ onLoggedIn, handleNavigationEvents, initialBlock }) => {
+const CorbadoAuth: FC<CorbadoAuthConfig> = ({ onLoggedIn, handleNavigationEvents, initialBlock, autoFocus = true }) => {
   return (
     <FlowHandlerProvider
       onLoggedIn={onLoggedIn}
       handleNavigationEvents={handleNavigationEvents}
       initialBlock={initialBlock as BlockTypes}
     >
-      <AuthFlow />
+      <AuthFlow autoFocus={autoFocus} />
     </FlowHandlerProvider>
   );
 };

--- a/packages/react/src/screens/core/CorbadoAuth.tsx
+++ b/packages/react/src/screens/core/CorbadoAuth.tsx
@@ -6,7 +6,12 @@ import React from 'react';
 import { AuthFlow } from '../../components';
 import FlowHandlerProvider from '../../contexts/FlowHandlerProvider';
 
-const CorbadoAuth: FC<CorbadoAuthConfig> = ({ onLoggedIn, handleNavigationEvents, initialBlock, initialAutoFocus = true }) => {
+const CorbadoAuth: FC<CorbadoAuthConfig> = ({
+  onLoggedIn,
+  handleNavigationEvents,
+  initialBlock,
+  initialAutoFocus = true,
+}) => {
   return (
     <FlowHandlerProvider
       onLoggedIn={onLoggedIn}

--- a/packages/react/src/screens/core/Login.tsx
+++ b/packages/react/src/screens/core/Login.tsx
@@ -6,7 +6,12 @@ import React from 'react';
 import { AuthFlow } from '../../components';
 import FlowHandlerProvider from '../../contexts/FlowHandlerProvider';
 
-const Login: FC<CorbadoLoginConfig> = ({ handleNavigationEvents, onLoggedIn, navigateToSignUp, initialAutoFocus = true }) => {
+const Login: FC<CorbadoLoginConfig> = ({
+  handleNavigationEvents,
+  onLoggedIn,
+  navigateToSignUp,
+  initialAutoFocus = true,
+}) => {
   return (
     <FlowHandlerProvider
       handleNavigationEvents={handleNavigationEvents}

--- a/packages/react/src/screens/core/Login.tsx
+++ b/packages/react/src/screens/core/Login.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { AuthFlow } from '../../components';
 import FlowHandlerProvider from '../../contexts/FlowHandlerProvider';
 
-const Login: FC<CorbadoLoginConfig> = ({ handleNavigationEvents, onLoggedIn, navigateToSignUp }) => {
+const Login: FC<CorbadoLoginConfig> = ({ handleNavigationEvents, onLoggedIn, navigateToSignUp, autoFocus = true }) => {
   return (
     <FlowHandlerProvider
       handleNavigationEvents={handleNavigationEvents}
@@ -14,7 +14,7 @@ const Login: FC<CorbadoLoginConfig> = ({ handleNavigationEvents, onLoggedIn, nav
       onChangeFlow={navigateToSignUp}
       initialFlowType={AuthType.Login}
     >
-      <AuthFlow />
+      <AuthFlow autoFocus={autoFocus} />
     </FlowHandlerProvider>
   );
 };

--- a/packages/react/src/screens/core/Login.tsx
+++ b/packages/react/src/screens/core/Login.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { AuthFlow } from '../../components';
 import FlowHandlerProvider from '../../contexts/FlowHandlerProvider';
 
-const Login: FC<CorbadoLoginConfig> = ({ handleNavigationEvents, onLoggedIn, navigateToSignUp, autoFocus = true }) => {
+const Login: FC<CorbadoLoginConfig> = ({ handleNavigationEvents, onLoggedIn, navigateToSignUp, initialAutoFocus = true }) => {
   return (
     <FlowHandlerProvider
       handleNavigationEvents={handleNavigationEvents}
@@ -14,7 +14,7 @@ const Login: FC<CorbadoLoginConfig> = ({ handleNavigationEvents, onLoggedIn, nav
       onChangeFlow={navigateToSignUp}
       initialFlowType={AuthType.Login}
     >
-      <AuthFlow autoFocus={autoFocus} />
+      <AuthFlow initialAutoFocus={initialAutoFocus} />
     </FlowHandlerProvider>
   );
 };

--- a/packages/react/src/screens/core/SignUp.tsx
+++ b/packages/react/src/screens/core/SignUp.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { AuthFlow } from '../../components';
 import FlowHandlerProvider from '../../contexts/FlowHandlerProvider';
 
-const SignUp: FC<CorbadoSignUpConfig> = ({ handleNavigationEvents, onSignedUp, navigateToLogin }) => {
+const SignUp: FC<CorbadoSignUpConfig> = ({ handleNavigationEvents, onSignedUp, navigateToLogin, autoFocus = true }) => {
   return (
     <FlowHandlerProvider
       handleNavigationEvents={handleNavigationEvents}
@@ -14,7 +14,7 @@ const SignUp: FC<CorbadoSignUpConfig> = ({ handleNavigationEvents, onSignedUp, n
       onChangeFlow={navigateToLogin}
       initialFlowType={AuthType.SignUp}
     >
-      <AuthFlow />
+      <AuthFlow autoFocus={autoFocus} />
     </FlowHandlerProvider>
   );
 };

--- a/packages/react/src/screens/core/SignUp.tsx
+++ b/packages/react/src/screens/core/SignUp.tsx
@@ -6,7 +6,12 @@ import React from 'react';
 import { AuthFlow } from '../../components';
 import FlowHandlerProvider from '../../contexts/FlowHandlerProvider';
 
-const SignUp: FC<CorbadoSignUpConfig> = ({ handleNavigationEvents, onSignedUp, navigateToLogin, initialAutoFocus = true }) => {
+const SignUp: FC<CorbadoSignUpConfig> = ({
+  handleNavigationEvents,
+  onSignedUp,
+  navigateToLogin,
+  initialAutoFocus = true,
+}) => {
   return (
     <FlowHandlerProvider
       handleNavigationEvents={handleNavigationEvents}

--- a/packages/react/src/screens/core/SignUp.tsx
+++ b/packages/react/src/screens/core/SignUp.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { AuthFlow } from '../../components';
 import FlowHandlerProvider from '../../contexts/FlowHandlerProvider';
 
-const SignUp: FC<CorbadoSignUpConfig> = ({ handleNavigationEvents, onSignedUp, navigateToLogin, autoFocus = true }) => {
+const SignUp: FC<CorbadoSignUpConfig> = ({ handleNavigationEvents, onSignedUp, navigateToLogin, initialAutoFocus = true }) => {
   return (
     <FlowHandlerProvider
       handleNavigationEvents={handleNavigationEvents}
@@ -14,7 +14,7 @@ const SignUp: FC<CorbadoSignUpConfig> = ({ handleNavigationEvents, onSignedUp, n
       onChangeFlow={navigateToLogin}
       initialFlowType={AuthType.SignUp}
     >
-      <AuthFlow autoFocus={autoFocus} />
+      <AuthFlow initialAutoFocus={initialAutoFocus} />
     </FlowHandlerProvider>
   );
 };

--- a/packages/types/src/component.ts
+++ b/packages/types/src/component.ts
@@ -33,6 +33,7 @@ export interface CorbadoAuthConfig {
   onLoggedIn: () => void;
   handleNavigationEvents?: boolean;
   initialBlock?: 'signup-init' | 'login-init';
+  autoFocus?: boolean;
 }
 
 /**
@@ -46,6 +47,7 @@ export interface CorbadoSignUpConfig {
   onSignedUp: () => void;
   navigateToLogin?: () => void;
   handleNavigationEvents?: boolean;
+  autoFocus?: boolean;
 }
 
 /**
@@ -59,4 +61,5 @@ export interface CorbadoLoginConfig {
   onLoggedIn: () => void;
   navigateToSignUp?: () => void;
   handleNavigationEvents?: boolean;
+  autoFocus?: boolean;
 }

--- a/packages/types/src/component.ts
+++ b/packages/types/src/component.ts
@@ -33,7 +33,7 @@ export interface CorbadoAuthConfig {
   onLoggedIn: () => void;
   handleNavigationEvents?: boolean;
   initialBlock?: 'signup-init' | 'login-init';
-  autoFocus?: boolean;
+  initialAutoFocus?: boolean;
 }
 
 /**
@@ -47,7 +47,7 @@ export interface CorbadoSignUpConfig {
   onSignedUp: () => void;
   navigateToLogin?: () => void;
   handleNavigationEvents?: boolean;
-  autoFocus?: boolean;
+  initialAutoFocus?: boolean;
 }
 
 /**
@@ -61,5 +61,5 @@ export interface CorbadoLoginConfig {
   onLoggedIn: () => void;
   navigateToSignUp?: () => void;
   handleNavigationEvents?: boolean;
-  autoFocus?: boolean;
+  initialAutoFocus?: boolean;
 }

--- a/playground/react/src/pages/AuthPage.tsx
+++ b/playground/react/src/pages/AuthPage.tsx
@@ -14,10 +14,7 @@ const AuthPage = () => {
     <>
       <Header />
       <div className='component'>
-        <CorbadoAuth
-          onLoggedIn={onLoggedIn}
-          autoFocus={false}
-        />
+        <CorbadoAuth onLoggedIn={onLoggedIn} />
       </div>
     </>
   );

--- a/playground/react/src/pages/AuthPage.tsx
+++ b/playground/react/src/pages/AuthPage.tsx
@@ -14,7 +14,10 @@ const AuthPage = () => {
     <>
       <Header />
       <div className='component'>
-        <CorbadoAuth onLoggedIn={onLoggedIn} />
+        <CorbadoAuth
+          onLoggedIn={onLoggedIn}
+          autoFocus={false}
+        />
       </div>
     </>
   );


### PR DESCRIPTION
Add config option `autoFocus` to `CorbadoAuth`, `SignUp` and `Login`. It is optional and  set to `true` by default so previous behavior stays consistent. If `false`, it will prevent autoFocus of input fields in both signup-init and login-init blocks, so only "entry" blocks are affected.