### PR TITLE
Add situation config to connect append component

### DIFF
--- a/packages/connect-react/src/components/append/AppendInitScreen.tsx
+++ b/packages/connect-react/src/components/append/AppendInitScreen.tsx
@@ -80,7 +80,7 @@ const AppendInitScreen = () => {
         getConnectService().setInvitation(invitationToken);
       }
 
-      const res = await getConnectService().appendInit(ac);
+      const res = await getConnectService().appendInit(ac, config.situation);
       if (res.err) {
         if (res.val.type === ConnectErrorType.Cancel) {
           return;
@@ -107,7 +107,13 @@ const AppendInitScreen = () => {
         return handleSituation(AppendSituationCode.CtApiNotAvailablePreAuthenticator);
       }
 
-      const startAppendRes = await getConnectService().startAppend(appendToken, loadedMs, ac);
+      const startAppendRes = await getConnectService().startAppend(
+        appendToken,
+        loadedMs,
+        ac,
+        undefined,
+        config.situation,
+      );
       if (startAppendRes.err) {
         if (startAppendRes.val.type === ConnectErrorType.Cancel) {
           return;

--- a/packages/types/src/connect/config.ts
+++ b/packages/types/src/connect/config.ts
@@ -26,6 +26,7 @@ export type CorbadoConnectAppendConfig = {
   onError?(error: string): void;
   onSkip(status: AppendStatus): Promise<void>;
   onComplete(status: AppendStatus, clientState: string): Promise<void>;
+  situation?: string;
 };
 
 export type AppendStatus = 'skip-implicit' | 'skip-explicit' | 'complete' | 'complete-noop';

--- a/packages/web-core/src/services/ConnectService.ts
+++ b/packages/web-core/src/services/ConnectService.ts
@@ -350,7 +350,10 @@ export class ConnectService {
     return loginFinishResp;
   }
 
-  async appendInit(abortController: AbortController): Promise<Result<ConnectAppendInitData, ConnectError>> {
+  async appendInit(
+    abortController: AbortController,
+    situation?: string,
+  ): Promise<Result<ConnectAppendInitData, ConnectError>> {
     const existingProcess = ConnectProcess.loadFromStorage(this.#projectId);
     if (existingProcess) {
       log.debug('process exists, preparing api clients');
@@ -363,7 +366,10 @@ export class ConnectService {
       }
     }
 
-    const { req, flags } = await this.#getInitReq();
+    const { req, flags } = await this.#getInitReq<ConnectAppendInitReq>();
+    if (situation) {
+      req.situation = situation;
+    }
     const res = await this.wrapWithErr(() =>
       this.#connectApi.connectAppendInit(req, { signal: abortController.signal }),
     );
@@ -419,15 +425,16 @@ export class ConnectService {
     loadedMs: number,
     abortController?: AbortController,
     initiatedByUser?: boolean,
+    situation?: string,
   ): Promise<Result<ConnectAppendStartRsp, ConnectError>> {
-    const existingProcess = await this.#getExistingProcess(() => this.appendInit(new AbortController()));
+    const existingProcess = await this.#getExistingProcess(() => this.appendInit(new AbortController(), situation));
     if (!existingProcess) {
       return Err(new ConnectError(ConnectErrorType.MissingInit));
     }
 
     return this.wrapWithErr(() =>
       this.#connectApi.connectAppendStart(
-        { appendTokenValue: appendTokenValue, forcePasskeyAppend: initiatedByUser, loadedMs },
+        { appendTokenValue, forcePasskeyAppend: initiatedByUser, loadedMs, situation },
         abortController && { signal: abortController.signal },
       ),
     );


### PR DESCRIPTION
## Expose `situation` parameter on CorbadoConnectAppend

### Summary
- Add optional `situation` prop to `CorbadoConnectAppendConfig`, allowing consumers to specify the append context (e.g. `"post-login"`, `"passkey-list"`, or any custom value)
- Thread `situation` through `ConnectService.appendInit()` and `ConnectService.startAppend()` into both `ConnectAppendInitReq` and `ConnectAppendStartReq` API payloads
- Wire the prop from `AppendInitScreen` so it's passed automatically on both init and start calls

### Changed files
- `packages/types/src/connect/config.ts` — add `situation?: string` to `CorbadoConnectAppendConfig`
- `packages/web-core/src/services/ConnectService.ts` — accept `situation` param in `appendInit` and `startAppend`
- `packages/connect-react/src/components/append/AppendInitScreen.tsx` — forward `config.situation` to service calls