### PR TITLE
Add `message` to expected `append-error` for web to collect messages

### DIFF
--- a/packages/connect-react/src/contexts/AppendProcessProvider.tsx
+++ b/packages/connect-react/src/contexts/AppendProcessProvider.tsx
@@ -29,10 +29,11 @@ export const AppendProcessProvider: FC<PropsWithChildren<Props>> = ({ children, 
 
   const handleErrorSoft = useCallback(
     async (situationCode: AppendSituationCode, expected: boolean, showError: boolean, error?: ConnectError) => {
+      const messageCode = `situation: ${situationCode} ${error?.track()}`;
       if (expected) {
-        await getConnectService().recordEventAppendError();
+        await getConnectService().recordEventAppendError(messageCode);
       } else {
-        await getConnectService().recordEventAppendErrorUnexpected(`situation: ${situationCode} ${error?.track()}`);
+        await getConnectService().recordEventAppendErrorUnexpected(messageCode);
       }
 
       if (showError) {
@@ -44,10 +45,11 @@ export const AppendProcessProvider: FC<PropsWithChildren<Props>> = ({ children, 
 
   const handleErrorHard = useCallback(
     async (situationCode: AppendSituationCode, expected: boolean, error?: ConnectError) => {
+      const messageCode = `situation: ${situationCode} ${error?.track()}`;
       if (expected) {
-        await getConnectService().recordEventAppendError();
+        await getConnectService().recordEventAppendError(messageCode);
       } else {
-        await getConnectService().recordEventAppendErrorUnexpected(`situation: ${situationCode} ${error?.track()}`);
+        await getConnectService().recordEventAppendErrorUnexpected(messageCode);
       }
 
       config.onError?.(situationCode.toString());

--- a/packages/web-core/src/services/ConnectService.ts
+++ b/packages/web-core/src/services/ConnectService.ts
@@ -660,8 +660,8 @@ export class ConnectService {
     return this.#recordEvent(PasskeyEventType.AppendCredentialExists, messageCode, challenge);
   }
 
-  recordEventAppendError() {
-    return this.#recordEvent(PasskeyEventType.AppendError);
+  recordEventAppendError(messageCode?: string) {
+    return this.#recordEvent(PasskeyEventType.AppendError, messageCode);
   }
 
   recordEventLoginErrorUnexpected(messageCode: string) {


### PR DESCRIPTION
## Summary

Expected append errors (`append-error` events) were missing the `messageCode` entirely — 12,252 events had NULL messages. This aligns the web SDK with `corbado-ios` and `corbado-android`, which always include situation + error details for both expected and unexpected errors.

### Cross-SDK comparison (before/after)

| | Expected error (append-error) | Unexpected error (append-error-unexpected) |
|---|---|---|
| **iOS** (CorbadoClient.swift) | "situation: {rawValue} {message}" | "situation: {rawValue} {message}" |
| **Android** (CorbadoClient.kt) | "situation: {ordinal} message: {msg} cause: {cause}" | "situation: {ordinal} message: {msg} cause: {cause}" |
| **Web (before)** | **NULL — no message passed** | "situation: {code} type: {type} message: {msg} runtime: {ms}" |
| **Web (after)** | "situation: {code} type: {type} message: {msg} runtime: {ms}" | "situation: {code} type: {type} message: {msg} runtime: {ms}" (unchanged) |

## Changes

- **AppendProcessProvider.tsx**: Extract messageCode before the expected/unexpected branch in both handleErrorSoft and handleErrorHard, pass it to recordEventAppendError(messageCode).
- **ConnectService.ts**: Change recordEventAppendError() signature to accept messageCode?: string and forward it to #recordEvent.