### PR TITLE
Fix session-token recovery after cookie expiry

### DIFF
--- a/packages/web-core/src/services/SessionService.ts
+++ b/packages/web-core/src/services/SessionService.ts
@@ -257,7 +257,8 @@ export class SessionService {
     const sessionTokenModel = new SessionToken(sessionToken);
 
     this.#setSessionToken(sessionTokenModel);
-    this.#setApisV2(refreshToken ?? '');
+    // a refresh response carries no new refresh-token => keep the stored one (payload mode has no cookie fallback)
+    this.#setApisV2(refreshToken ?? this.#refreshToken ?? '');
 
     this.#onSessionTokenChange(sessionTokenModel);
     this.#setRefreshToken(refreshToken);

--- a/packages/web-core/src/services/SessionService.ts
+++ b/packages/web-core/src/services/SessionService.ts
@@ -21,6 +21,7 @@ import {
   AuthState,
   base64decode,
   CorbadoError,
+  NonRecoverableError,
   PasskeyAlreadyExistsError,
   type PasskeyDeleteError,
   PasskeysNotSupported,
@@ -100,16 +101,17 @@ export class SessionService {
     this.#sessionConfig = sessionConfig.val;
     this.#refreshToken = SessionService.#getRefreshToken();
     this.#sessionToken = SessionService.#getSessionToken();
+    this.#setApisV2(this.#refreshToken);
 
     // if the session is valid, we emit it
     if (this.#sessionToken && this.#sessionToken.isValidForXMoreSeconds(0)) {
       log.debug('emit session-token', this.#sessionToken);
       this.#onSessionTokenChange(this.#sessionToken);
     } else {
-      await this.#handleRefreshRequest();
+      // the session-token cookie may have expired while a valid refresh session still exists
+      // (HTTP-only cookie) => attempt one recovery refresh, the server decides
+      await this.#refresh();
     }
-
-    this.#setApisV2(this.#refreshToken);
 
     // init scheduled session refresh
     this.#refreshIntervalId = setInterval(() => {
@@ -456,9 +458,14 @@ export class SessionService {
 
       this.setSession(response.data.sessionToken, undefined);
     } catch (e) {
-      // if it's a network error, we should do a retry
-      // for all other errors, we should log out the user
       log.warn(e);
+
+      // transient network failure (e.g. wake from sleep before the network is back up):
+      // keep the session, the scheduled refresh retries => log out only on real backend rejections
+      if (!navigator.onLine || (e instanceof NonRecoverableError && e.message.includes('no_data_in_response'))) {
+        return;
+      }
+
       await this.logout();
     }
   }


### PR DESCRIPTION
- `init()` recovery was vetoed by the missing-token guard in `#handleRefreshRequest`: after the 5-min `cbo_session_token` cookie expires (tab discard/close, reload), no refresh was attempted even though the HTTP-only refresh session was still valid, forcing a full re-login
- `init()` now calls `#refresh()` directly for the recovery attempt; interval/visibility paths keep the guard, so logged-out users are not polled
- `#setApisV2` moved before the recovery attempt; previously the initial refresh could run on the unconfigured default `UsersApi` (placeholder host, no credentials) and always fail
- `#refresh()` no longer logs out on transient network failures (e.g. wake from sleep before connectivity is back); the 10s scheduled refresh retries. Logout still happens on real backend rejections
- `setSession` keeps the stored refresh-token on the API client when a refresh response carries none; the old post-refresh `#setApisV2` call in `init()` restored it accidentally, and the reordering above removed that safety net — without this, payload-mode (localStorage refresh-token, no cookie) loses `Authorization` after the first refresh
- behavior note: a cold load with no session now issues one refresh attempt that 401s for anonymous visitors before settling on LoggedOut